### PR TITLE
fix: rand intn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,18 +6,21 @@ require (
 	github.com/lxzan/concurrency v1.2.0
 	github.com/lxzan/gws v1.6.1
 	github.com/rs/zerolog v1.29.1
+	github.com/stretchr/testify v1.8.2
 	github.com/urfave/cli/v2 v2.25.3
 )
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/klauspost/compress v1.16.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsr
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/random.go
+++ b/internal/random.go
@@ -40,7 +40,7 @@ func (c *RandomString) Generate(n int) []byte {
 
 func (c *RandomString) Intn(n int) int {
 	c.mu.Lock()
-	x := rand.Intn(n)
+	x := c.r.Intn(n)
 	c.mu.Unlock()
 	return x
 }

--- a/internal/random_test.go
+++ b/internal/random_test.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlphabetNumeric(t *testing.T) {
+	count := 1000
+	set := make(map[string]struct{}, count)
+
+	for i := 0; i < count; i++ {
+		bs := AlphabetNumeric.Generate(100)
+		if len(bs) != 100 {
+			t.Error("generate error")
+			return
+		}
+		set[string(bs)] = struct{}{}
+	}
+
+	assert.Equal(t, count, len(set))
+}
+
+func TestNumeric(t *testing.T) {
+	count := 1000
+	for i := 0; i < count; i++ {
+		num := AlphabetNumeric.Intn(100)
+
+		// n >= 0
+		assert.GreaterOrEqual(t, num, 0)
+		// n <= 100
+		assert.LessOrEqual(t, num, 100)
+	}
+}


### PR DESCRIPTION
### change

1. 使用独立的 rand 对象，避免全局 rand lock 竞争。
2. 补充单元测试